### PR TITLE
MediaWiki 1.27 LTS support

### DIFF
--- a/checkfchw.php
+++ b/checkfchw.php
@@ -39,7 +39,7 @@ $wgHooks['LanguageGetSpecialPageAliases'][] = 'checkfchwLocalizedPageName'; # Ad
 function checkfchwLocalizedPageName(&$specialPageArray, $code) {
   # The localized title of the special page is among the messages of the extension:
   // wfLoadExtensionMessages('checkfchw'); // removed in MW-1.21.1
-  $text = wfMsg('checkfchw');
+  $text = wfMessage('checkfchw')->text();
 
   # Convert from title in text form to DBKey and put it into the alias array:
   $title = Title::newFromText($text);


### PR DESCRIPTION
wfMsg() has been deprecated

See 
https://www.mediawiki.org/wiki/Manual:Messages_API#Help_with_replacing_deprecated_wfMsg.2A_functions